### PR TITLE
Allow a server hostname override for JIDs

### DIFF
--- a/lib/xmpp4r-simple.rb
+++ b/lib/xmpp4r-simple.rb
@@ -82,11 +82,17 @@ module Jabber
     # to the Jabber server and your status message will be set to the string
     # passed in as the status_message argument.
     #
+    # If you'd like to connect to a different talk server than the one which would
+    # be guessed from your jid, you may provide a server. For example, to connect
+    # to the gmail talk servers with a jid that doesn't end in @gmail.com, just provide
+    # 'talk.l.google.com' as the server. You may leave server as nil to use the default.
+    #
     # jabber = Jabber::Simple.new("me@example.com", "password", "Chat with me - Please!")
-    def initialize(jid, password, status = nil, status_message = "Available")
+    def initialize(jid, password, status = nil, status_message = "Available", server=nil)
       @jid = jid
       @password = password
       @disconnected = false
+      @server = server
       status(status, status_message)
       start_deferred_delivery_thread
     end
@@ -391,7 +397,7 @@ module Jabber
       # Connect
       jid = JID.new(@jid)
       my_client = Client.new(@jid)
-      my_client.connect
+      my_client.connect(@server)
       my_client.auth(@password)
       self.client = my_client
 


### PR DESCRIPTION
Right now if you want to connect with Jabber::Simple using a gmail address which doesn't end in @gmail.com (for example, if you're using google apps for domains), it will break, because it will attempt to look up the talk server for your apps-for-domains location. I added an override so you can provide a server to connect directly to. 

I think I sent this request already but I wanted to try the new pull-request system.
