### PR TITLE
Typo / Syntax error in README

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Jabber::Simple - An extremely easy-to-use Jabber client library.
 
   # Get presence updates from your friends, and print them out to the console:
   # (admittedly, this one needs some work)
-  im.presence_updates { |update|
+  im.presence_updates do |update|
     from     = update[0].jid.strip.to_s
     status   = update[2].status
     presence = update[2].show


### PR DESCRIPTION
Heyo.

Thanks for this awesome library.
I see in the README's presence_updates() example - there's a mixture of curly-bracket and do/end syntax.
